### PR TITLE
chore(biome): migrate config to CLI v2.5.5

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -39,7 +39,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "complexity": {
         "noForEach": "off",
         "useArrowFunction": "error"


### PR DESCRIPTION
## Summary

Run `biome migrate` to align `biome.json` with the installed Biome CLI (v2.5.5, bumped in #157). Removes the two informational warnings biome was emitting on every `pnpm check`:

- `$schema` bumped from `2.4.15` → `2.5.5` (schema/CLI version mismatch).
- Deprecated `linter.rules.recommended: true` replaced with `linter.rules.preset: "recommended"` (the `recommended` field is deprecated and will be removed in the next major).

No rule behaviour changes — purely a config-format migration performed by biome's own tool.

## Verification

- `pnpm check` → `Checked 29 files. No fixes applied.` (previously `Found 2 infos.`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)