### PR TITLE
chore(deps): fix pnpm audit findings (undici, postcss, nanoid)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,12 @@ settings:
 
 overrides:
   rollup@>=4.0.0 <4.59.0: 4.62.2
-  undici@>=6.0.0 <6.27.0: 8.8.0
+  undici@<8.9.0: ^8.9.0
   picomatch@<2.3.2: '>=2.3.2'
   yaml@>=2.0.0 <2.8.3: '>=2.8.3'
   '@babel/core@<7.29.1': 7.29.7
+  postcss@<8.5.23: ^8.5.23
+  nanoid@<3.3.17: ^3.3.17
 
 importers:
 
@@ -1059,8 +1061,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1091,8 +1093,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.20:
-    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   property-expr@2.0.6:
@@ -1192,8 +1194,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@8.8.0:
-    resolution: {integrity: sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   universal-user-agent@7.0.3:
@@ -1331,17 +1333,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.8
       '@octokit/request-error': 7.1.0
-      undici: 8.8.0
+      undici: 8.10.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 8.8.0
+      undici: 8.10.0
 
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 8.8.0
+      undici: 8.10.0
 
   '@actions/io@3.0.2': {}
 
@@ -2124,7 +2126,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   node-releases@2.0.27: {}
 
@@ -2185,9 +2187,9 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.20:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2293,7 +2295,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@8.8.0: {}
+  undici@8.10.0: {}
 
   universal-user-agent@7.0.3: {}
 
@@ -2307,7 +2309,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.20
+      postcss: 8.5.26
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,13 @@
 overrides:
   "rollup@>=4.0.0 <4.59.0": "4.62.2"
-  "undici@>=6.0.0 <6.27.0": "8.8.0"
+  # 2026-08-10: undici <8.9.0 — GHSA-4cwx-7wf7-3272 (high), GHSA-8xcm-r25x-g524,
+  # GHSA-m8rv-5g2x-5cg5, GHSA-jr45-8vmc-qm54, GHSA-v3r7-h72x-cjcm (moderate).
+  # Supersedes the earlier <6.27.0 override, which pinned the now-vulnerable 8.8.0.
+  "undici@<8.9.0": "^8.9.0"
   "picomatch@<2.3.2": ">=2.3.2"
   "yaml@>=2.0.0 <2.8.3": ">=2.8.3"
   "@babel/core@<7.29.1": "7.29.7"
+  # 2026-08-10: postcss <=8.5.22 — GHSA-fxqj-rqcc-2cmp (moderate)
+  "postcss@<8.5.23": "^8.5.23"
+  # 2026-08-10: nanoid <3.3.17 — GHSA-2v37-7h3g-55p8 (high)
+  "nanoid@<3.3.17": "^3.3.17"


### PR DESCRIPTION
Clears all seven `pnpm audit` findings (scope: **all severities** — 2 high, 5 moderate). Every finding was transitive-only, so each is fixed with a comparator-scoped override in `pnpm-workspace.yaml`. No direct dependency needed bumping, and nothing was suppressed via `ignoreGhsas`.

## Transitive overrides

| Module | Installed | Override | Reached via |
| --- | --- | --- | --- |
| `undici` | 8.8.0 | `undici@<8.9.0` → `^8.9.0` | `@actions/core`, `@actions/github` |
| `postcss` | 8.5.20 | `postcss@<8.5.23` → `^8.5.23` | `vite` |
| `nanoid` | 3.3.16 | `nanoid@<3.3.17` → `^3.3.17` | `vite` → `postcss` |

All three stay within the installed major, so there is no API-break risk for the parents.

### Note on `undici`

The pre-existing override was `"undici@>=6.0.0 <6.27.0": "8.8.0"` — an exact pin that had itself become vulnerable. It is replaced by `"undici@<8.9.0": "^8.9.0"`, which still covers the original 6.x range *and* the newly-vulnerable 8.0–8.8 line, and uses a caret range so future patch releases in the 8.x line flow through without another manual override bump.

## Advisories fixed

- `undici` — [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) (**high**) — cross-user information disclosure and parse-time crash via degenerate private cache directives
- `undici` — [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) (moderate) — downstream response desynchronisation via retry interceptor
- `undici` — [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) (moderate) — CRLF injection via blob-like body `type` property
- `undici` — [GHSA-jr45-8vmc-qm54](https://github.com/advisories/GHSA-jr45-8vmc-qm54) (moderate) — cross-user information disclosure via whitespace around equals in `Cache-Control` directives
- `undici` — [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) (moderate) — cookie attribute injection via unsanitised domain and unparsed `setCookie` fields
- `nanoid` — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (**high**) — custom generators can loop indefinitely when size is zero
- `postcss` — [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) (moderate) — attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset

## Verification

- `pnpm install --frozen-lockfile` — clean, no specifier drift
- `pnpm test` — 26 tests across 10 files pass, 100% coverage
- `pnpm audit --audit-level=low` — **no known vulnerabilities found**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
